### PR TITLE
Cope when `request` gives us a null response

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,8 @@ var Capsule = function(account, key) {
     request(opt, function(err, res, body) {
       if (err)
         return cb(err);
+      if (res === undefined || res === null)
+        return cb(new Error('Request returned with empty response'));
       if (res.statusCode !== 200 && res.statusCode !== 201)
         return cb(new Error('Request returned with an invalid status code of: ' + res.statusCode + ', body:' + body));
       return cb(null, body ? JSON.parse(body) : null, res);


### PR DESCRIPTION
There is a similar line added (by us) in the previous commit, https://github.com/peardeck/capsule-crm/commit/03a741d760bc689dd74c3da8bbfe02a8852174b9, which I think turns into dead code with this commit. But I'm feeling loath to meddle too much and am inclined to leave the cruft rather than risk having our server go crashy-crash again.
